### PR TITLE
Add case for linux-gnu: run with docker internal host

### DIFF
--- a/docker/create_container.sh
+++ b/docker/create_container.sh
@@ -3,20 +3,12 @@
 # Create the docker container with a bind mount:
 echo "Creating container..."
 . ./docker_config.sh
-if [ -n "ON_LINUX" ]; then
-  execute "docker run -d \
-    --name $DOCKER_CONTAINER_NAME \
-    --mount type=bind,source=\"$(pwd)\"/../..,target=/share \
-    --add-host=host.docker.internal:host-gateway \
-    $DOCKER_IMAGE_NAME \
-    sleep infinity"
-else
-  execute "docker run -d \
-    --name $DOCKER_CONTAINER_NAME \
-    --mount type=bind,source=\"$(pwd)\"/../..,target=/share \
-    $DOCKER_IMAGE_NAME \
-    sleep infinity"
-fi
+execute "docker run -d \
+  --name $DOCKER_CONTAINER_NAME \
+  --mount type=bind,source=\"$(pwd)\"/../..,target=/share \
+  $ON_LINUX \
+  $DOCKER_IMAGE_NAME \
+  sleep infinity"
 
 # Run docker provision script inside of container to get things set up:
 echo "Provisioning container..."

--- a/docker/create_container.sh
+++ b/docker/create_container.sh
@@ -3,11 +3,20 @@
 # Create the docker container with a bind mount:
 echo "Creating container..."
 . ./docker_config.sh
-execute "docker run -d \
-  --name $DOCKER_CONTAINER_NAME \
-  --mount type=bind,source=\"$(pwd)\"/../..,target=/share \
-  $DOCKER_IMAGE_NAME \
-  sleep infinity"
+if [ -n "ON_LINUX" ]; then
+  execute "docker run -d \
+    --name $DOCKER_CONTAINER_NAME \
+    --mount type=bind,source=\"$(pwd)\"/../..,target=/share \
+    --add-host=host.docker.internal:host-gateway \
+    $DOCKER_IMAGE_NAME \
+    sleep infinity"
+else
+  execute "docker run -d \
+    --name $DOCKER_CONTAINER_NAME \
+    --mount type=bind,source=\"$(pwd)\"/../..,target=/share \
+    $DOCKER_IMAGE_NAME \
+    sleep infinity"
+fi
 
 # Run docker provision script inside of container to get things set up:
 echo "Provisioning container..."

--- a/docker/create_container.sh
+++ b/docker/create_container.sh
@@ -3,6 +3,14 @@
 # Create the docker container with a bind mount:
 echo "Creating container..."
 . ./docker_config.sh
+
+ON_LINUX=""
+case "$OSTYPE" in
+  linux*)
+    ON_LINUX="--add-host=host.docker.internal:host-gateway"
+    ;;
+esac
+
 execute "docker run -d \
   --name $DOCKER_CONTAINER_NAME \
   --mount type=bind,source=\"$(pwd)\"/../..,target=/share \

--- a/docker/docker_config.sh
+++ b/docker/docker_config.sh
@@ -5,12 +5,13 @@ DOCKER_IMAGE_NAME="ghcr.io/lasp/adamant:example-latest"
 export DOCKER_CONTAINER_NAME
 export DOCKER_IMAGE_NAME
 
+ON_LINUX=""
 case "$OSTYPE" in
   linux*)
     ON_LINUX="--add-host=host.docker.internal:host-gateway"
-    export ON_LINUX
     ;;
 esac
+export ON_LINUX
 
 # Helper function to print out command as executed:
 execute () {

--- a/docker/docker_config.sh
+++ b/docker/docker_config.sh
@@ -5,6 +5,13 @@ DOCKER_IMAGE_NAME="ghcr.io/lasp/adamant:example-latest"
 export DOCKER_CONTAINER_NAME
 export DOCKER_IMAGE_NAME
 
+case "$OSTYPE" in
+  linux-gnu)
+    ON_LINUX="yes"
+    export ON_LINUX
+    ;;
+esac
+
 # Helper function to print out command as executed:
 execute () {
   echo "$ $@"

--- a/docker/docker_config.sh
+++ b/docker/docker_config.sh
@@ -6,8 +6,8 @@ export DOCKER_CONTAINER_NAME
 export DOCKER_IMAGE_NAME
 
 case "$OSTYPE" in
-  linux-gnu)
-    ON_LINUX="yes"
+  linux*)
+    ON_LINUX="--add-host=host.docker.internal:host-gateway"
     export ON_LINUX
     ;;
 esac

--- a/docker/docker_config.sh
+++ b/docker/docker_config.sh
@@ -5,14 +5,6 @@ DOCKER_IMAGE_NAME="ghcr.io/lasp/adamant:example-latest"
 export DOCKER_CONTAINER_NAME
 export DOCKER_IMAGE_NAME
 
-ON_LINUX=""
-case "$OSTYPE" in
-  linux*)
-    ON_LINUX="--add-host=host.docker.internal:host-gateway"
-    ;;
-esac
-export ON_LINUX
-
 # Helper function to print out command as executed:
 execute () {
   echo "$ $@"


### PR DESCRIPTION
Relating to comments in issue lasp#2, added case for `linux-gnu` OSTYPE to implement the internal host when creating the docker container on this platform.

Update docker_config.sh, create_container.sh