### PR TITLE
Add `pull` to `adamant_env.sh`

### DIFF
--- a/docker/adamant_env.sh
+++ b/docker/adamant_env.sh
@@ -42,6 +42,7 @@ usage() {
   echo "*  start: create and start the ${PROJECT_NAME} container" >&2
   echo "*  stop: stop the running ${PROJECT_NAME} container" >&2
   echo "*  login: login to the ${PROJECT_NAME} container" >&2
+  echo "*  pull: pull the latest image from the Docker registry" >&2
   echo "*  push: push the image to the Docker registry" >&2
   echo "*  build: build the image from the Dockerfile" >&2
   echo "*  remove: remove network and volumes for ${PROJECT_NAME}" >&2
@@ -63,6 +64,9 @@ case $1 in
     ;;
   login )
     execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} exec -it -u user ${PROJECT_NAME} //bin//bash"
+    ;;
+  pull )
+    execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} pull"
     ;;
   push )
     execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} push"


### PR DESCRIPTION
This adds the `pull` argument to the Docker container management script `adamant_env.sh`. This allows pulling and building new images with `./adamant_env.sh pull && ./adamant_env.sh start`, instead of having to remove/prune current images and running `./adamant_env.sh start` to pull the latest images.