### PR TITLE
Add missing interface arguments to Pico COSMOS plugin

### DIFF
--- a/src/assembly/pico/main/cosmos/plugin/plugin.txt
+++ b/src/assembly/pico/main/cosmos/plugin/plugin.txt
@@ -9,7 +9,7 @@ Variable port_r /dev/tty0
 
 Target Pico_Example <%= pico_example_target_name %>
 # Serial example interface:
-Interface <%= pico_example_target_name %>_INT serial_interface.rb <%= port_w %> <%= port_r %> 10.0 nil Length 64 16 11 1 Big_Endian 0 FED4AFEE
+Interface <%= pico_example_target_name %>_INT serial_interface.rb <%= port_w %> <%= port_r %> 115200 NONE 1 10.0 nil Length 64 16 11 1 Big_Endian 0 FED4AFEE
   Map_Target <%= pico_example_target_name %>
   Protocol Read crc_sync_protocol.rb <%= crc_parameter_name %> false "ERROR" -16 16
   Protocol Write cmd_sync_checksum.rb <%= checksum_parameter_name %>


### PR DESCRIPTION
This restores functionality to the Pico COSMOS plugin. The `plugin.txt` configuration now contains interface arguments for baud rate, parity, and stop bits. When missing from the plugin configuration, COSMOS will generate errors upon install. This has been tested as fixed on Linux with the latest Pico runtime.