### PR TITLE
Apply temporary fix to embedded-rpi-pico runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,5 +46,10 @@ RUN cp /root/.bashrc $HOME/.bashrc \
     && echo "cd $HOME && [ -f "~/adamant_example/env/activate" ] && source adamant_example/env/activate" >> $HOME/.bashrc \
     && chown -R $DOCKER_USER:$DOCKER_USER $HOME
 
+# Install wget. We need it to implement temporary fix
+# for https://github.com/alire-project/GNAT-FSF-builds/issues/69.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -yq wget
+
 # Make sure user is user at end.
 USER user

--- a/env/activate
+++ b/env/activate
@@ -27,6 +27,29 @@ export ADAMANT_CONFIGURATION_YAML=$EXAMPLE_DIR/config/example.configuration.yaml
 # Activate the Adamant environment:
 . $ADAMANT_DIR/env/activate $EXAMPLE_DIR
 
+# Temporary fix for https://github.com/alire-project/GNAT-FSF-builds/issues/69. This can
+# go away when a new release of gnat_arm_elf fixes this issue >14.1.3,
+# see: https://alire.ada.dev/crates/gnat_arm_elf
+arm_elf_dir=`which arm-eabi-gcc | xargs dirname | xargs dirname`
+pico_runtime_dir="$arm_elf_dir/arm-eabi/lib/gnat/embedded-rpi-pico"
+pico_runtime_gnarl_dir="$pico_runtime_dir/gnarl_user"
+mirror="https://raw.githubusercontent.com/gcc-mirror/gcc/releases/gcc-14/gcc/ada/libgnarl"
+installed=0
+if [[ ! -f "$pico_runtime_gnarl_dir/s-putaim.adb" ]]
+then
+  wget -P $pico_runtime_gnarl_dir $mirror/s-putaim.adb
+  installed=1
+fi
+if [[ ! -f "$pico_runtime_gnarl_dir/s-putaim.ads" ]]
+then
+  wget -P $pico_runtime_gnarl_dir $mirror/s-putaim.ads
+  installed=1
+fi
+if [[ $installed -eq 1 ]]
+then
+  gprbuild -P $pico_runtime_dir/ravenscar_build.gpr
+fi
+
 # Signify the environment it set up:
 export EXAMPLE_ENVIRONMENT_SET="yes"
 


### PR DESCRIPTION
This applies a temporary fix to the embedded-rpi-pico runtime installed with the Adamant example repository. It fixes:

https://github.com/alire-project/GNAT-FSF-builds/issues/69

to allow for compilation with the `-gnat2022` flag until a new release of gnat_arm_elf is available, ie.
https://alire.ada.dev/crates/gnat_arm_elf. This will likely be fixed in some version >14.1.3 and this temporary fix can be reverted.