### PR TITLE
Add Pico Safe and Analyze build targets

### DIFF
--- a/config/example.configuration.yaml
+++ b/config/example.configuration.yaml
@@ -115,6 +115,3 @@ command_registration_delay: 250 # microseconds
 # Examples of a project specific variables:
 # project_specific_variable: 17
 # project_specific_string: "This project rocks!"
-
-# Add URL to CodePeer IDE server:
-# codepeer_ide_server: http://path:8081

--- a/default.do
+++ b/default.do
@@ -82,8 +82,6 @@ if __name__ == "__main__":
         from rules.build_coverage_all import build_coverage_all as rule_cls
     elif base == "publish":
         from rules.build_publish import build_publish as rule_cls
-    elif base == "codepeer_server":
-        from rules.build_codepeer_server import build_codepeer_server as rule_cls
     elif base == "yaml_sloc":
         from rules.build_yaml_sloc import build_yaml_sloc as rule_cls
 

--- a/redo/environments/pico.py
+++ b/redo/environments/pico.py
@@ -2,7 +2,7 @@
 from util import target
 from os import environ, path
 
-target.set_target("Pico")
+target.set_target_if_not_set("Pico")
 try:
     adamant_dir = environ['ADAMANT_DIR']
 except KeyError:

--- a/redo/targets/gpr/pico_analyze.gpr
+++ b/redo/targets/gpr/pico_analyze.gpr
@@ -1,0 +1,40 @@
+with "pico_bsp.gpr";
+
+project pico_analyze extends all "a_bareboard_debug.gpr" is
+
+   -----------------------------------------------
+   -- These lines of code must be included at the
+   -- top of every Adamant based .gpr file. They
+   -- are used to connect the Adamant build system
+   -- to GPRBuild.
+   -----------------------------------------------
+   for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Object_Dir use a_adamant.OBJECT_DIR;
+   for Exec_Dir use a_adamant.EXEC_DIR;
+
+   -- Specify cross compiler ARM target and Ravenscar runtime:
+   for Target use "arm-eabi";
+   for Runtime ("Ada") use "embedded-rpi-pico";
+   -- C++ not supported for arm-eabi currently.
+   for Languages use ("Ada", "C", "ASM_CPP");
+
+   -- Common binder switches:
+   package Binder is
+      for Switches ("Ada") use a_bareboard_base.Binder'Switches ("Ada") &
+         -- Store tracebacks in exception occurrences
+         -- https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gnat_ugn_unw/Switches-for-gnatbind.html
+         ("-E");
+   end Binder;
+
+   package Linker is
+      for Switches ("Ada") use a_bareboard_base.Linker'Switches ("Ada");
+   end Linker;
+
+   -- Force analysis into "deep" mode
+   package Analyzer is
+      for Switches ("analyze") use ("--no-unused-annotate-warning", "--mode=deep");
+      for Additional_Patterns use a_adamant.ADAMANT_DIR &
+         "/redo/targets/gnatsas/AdamantMessagePatterns.xml";
+   end Analyzer;
+
+end pico_analyze;

--- a/redo/targets/gpr/pico_safe.gpr
+++ b/redo/targets/gpr/pico_safe.gpr
@@ -1,0 +1,33 @@
+with "pico_bsp.gpr";
+
+project pico_development extends all "a_bareboard_safe.gpr" is
+
+   -----------------------------------------------
+   -- These lines of code must be included at the
+   -- top of every Adamant based .gpr file. They
+   -- are used to connect the Adamant build system
+   -- to GPRBuild.
+   -----------------------------------------------
+   for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Object_Dir use a_adamant.OBJECT_DIR;
+   for Exec_Dir use a_adamant.EXEC_DIR;
+
+   -- Specify cross compiler ARM target and Ravenscar runtime:
+   for Target use "arm-eabi";
+   for Runtime ("Ada") use "embedded-rpi-pico";
+   -- C++ not supported for arm-eabi currently.
+   for Languages use ("Ada", "C", "ASM_CPP");
+
+   -- Common binder switches:
+   package Binder is
+      for Switches ("Ada") use a_bareboard_base.Binder'Switches ("Ada") &
+         -- Store tracebacks in exception occurrences
+         -- https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gnat_ugn_unw/Switches-for-gnatbind.html
+         ("-E");
+   end Binder;
+
+   package Linker is
+      for Switches ("Ada") use a_bareboard_base.Linker'Switches ("Ada");
+   end Linker;
+
+end pico_development;

--- a/redo/targets/pico.py
+++ b/redo/targets/pico.py
@@ -66,3 +66,42 @@ class Pico_Debug(Pico_Base):
             os.environ["EXAMPLE_DIR"],
             "redo" + os.sep + "targets" + os.sep + "gpr" + os.sep + "pico_debug.gpr",
         )
+
+
+class Pico_Safe(Pico_Base):
+    def description(self):
+        return """This target compiles for the Raspberry Pi Pico microprocessor. This is the
+               last resort image compilation. It has all runtime checks and assertions
+               disabled. It has optimization disabled. This is meant to create a different
+               binary than the Pico_Production target in order to possibly circumvent any compiler
+               bugs or runtime check bugs."""
+
+    def gpr_project_file(self):
+        return os.path.join(
+            os.environ["EXAMPLE_DIR"],
+            "redo"
+            + os.sep
+            + "targets"
+            + os.sep
+            + "gpr"
+            + os.sep
+            + "pico_safe.gpr",
+        )
+
+
+class Pico_Analyze(Pico_Base):
+    """Analyze target which runs GNAT SAS in deep mode."""
+    def description(self):
+        return ("Same as Pico_Debug except it adds deep mode switch for GNAT SAS.")
+
+    def gpr_project_file(self):
+        return os.path.join(
+            os.environ["EXAMPLE_DIR"],
+            "redo"
+            + os.sep
+            + "targets"
+            + os.sep
+            + "gpr"
+            + os.sep
+            + "pico_analyze.gpr",
+        )


### PR DESCRIPTION
The Analyze target is meant to be run with GNAT SAS on a CI server,
since it forces deep mode analysis. The Safe target is meant to provide
a "safe image" compile that has runtime checking and optimization turned
off. This can work around compile bugs or runtime check bugs in a last
resort image.