### PR TITLE
Update README.md  to disable the COSMOS demo

### DIFF
--- a/src/assembly/linux/main/README.md
+++ b/src/assembly/linux/main/README.md
@@ -50,6 +50,12 @@ The COSMOS Docker container must be configured to use the same ports as Adamant.
       - "127.0.0.1:7779:7779" # Event packets
 ```
 
+To prevent the COSMOS demo plugin from automatically installing itself each time the COSMOS containers are started, edit the environment configuration at `cosmos-project/.env` and comment out the following line:
+
+```
+# OPENC3_DEMO=1
+```
+
 Start COSMOS by running:
 
 ```

--- a/src/assembly/pico/main/README.md
+++ b/src/assembly/pico/main/README.md
@@ -154,6 +154,12 @@ $ ls /dev/tty*
 >       - "127.0.0.1:7779:7779" # Event packets
 > ```
 
+To prevent the COSMOS demo plugin from automatically installing itself each time the COSMOS containers are started, edit the environment configuration at `cosmos-project/.env` and comment out the following line:
+
+```
+# OPENC3_DEMO=1
+```
+
 Start COSMOS by running:
 
 ```


### PR DESCRIPTION
When started normally, the COSMOS container will always automatically install the demo plugin. This PR adds instructions to the assemblies' README to disable the automatic installation of the demo plugin.

Instruction in the environment file are adjacent to the variable controlling this behavior and are verbatim as follows:
```
# Comment this variable to disable installing the Demo (don't set it to 0)
OPENC3_DEMO=1
```

Commenting out this line will prevent the demo plugin from being reinstalled, but if any Adamant_Example plugin was previously installed, it will still be automatically reinstalled upon COSMOS container restart.