### PR TITLE
Fix init for serial interface for pico

### DIFF
--- a/src/assembly/pico/pico_example.assembly.yaml
+++ b/src/assembly/pico/pico_example.assembly.yaml
@@ -132,6 +132,8 @@ components:
     priority: 1
     stack_size: 2000
     secondary_stack_size: 100
+    init:
+      - "Interpacket_Gap_Ms => 0"
     init_base:
       - "Queue_Size => 4 * Ccsds_Space_Packet.Size_In_Bytes"
     subtasks:


### PR DESCRIPTION
This adds the new `Interpacket_Gap_Ms` init parameter for the CCSDS Serial Interface component in the Pico assembly.