### PR TITLE
Use Ada 2022 @ syntax

### DIFF
--- a/src/components/counter/component-counter-implementation.adb
+++ b/src/components/counter/component-counter-implementation.adb
@@ -19,7 +19,7 @@ package body Component.Counter.Implementation is
       Ignore_2 := Self.Dispatch_All;
 
       -- Increment the count and perform the counter action:
-      Self.The_Count := Self.The_Count + 1;
+      Self.The_Count := @ + 1;
       Counter_Action.Do_Action (Self.The_Count);
 
       -- Send the count value out:

--- a/src/components/counter/test/component-counter-implementation-tester.adb
+++ b/src/components/counter/test/component-counter-implementation-tester.adb
@@ -112,7 +112,7 @@ package body Component.Counter.Implementation.Tester is
       if not Self.Expect_Command_T_Send_Dropped then
          pragma Assert (False, "The component's queue filled up when Command_T_Send was called!");
       else
-         Self.Command_T_Send_Dropped_Count := Self.Command_T_Send_Dropped_Count + 1;
+         Self.Command_T_Send_Dropped_Count := @ + 1;
          Self.Expect_Command_T_Send_Dropped := False;
       end if;
    end Command_T_Send_Dropped;

--- a/src/components/oscillator/test/component-oscillator-implementation-tester.adb
+++ b/src/components/oscillator/test/component-oscillator-implementation-tester.adb
@@ -118,7 +118,7 @@ package body Component.Oscillator.Implementation.Tester is
       if not Self.Expect_Command_T_Send_Dropped then
          pragma Assert (False, "The component's queue filled up when Command_T_Send was called!");
       else
-         Self.Command_T_Send_Dropped_Count := Self.Command_T_Send_Dropped_Count + 1;
+         Self.Command_T_Send_Dropped_Count := @ + 1;
          Self.Expect_Command_T_Send_Dropped := False;
       end if;
    end Command_T_Send_Dropped;

--- a/src/components/parameter_manager/test/component-parameter_manager-implementation-tester.adb
+++ b/src/components/parameter_manager/test/component-parameter_manager-implementation-tester.adb
@@ -142,7 +142,7 @@ package body Component.Parameter_Manager.Implementation.Tester is
       if not Self.Expect_Command_T_Send_Dropped then
          pragma Assert (False, "The component's queue filled up when Command_T_Send was called!");
       else
-         Self.Command_T_Send_Dropped_Count := Self.Command_T_Send_Dropped_Count + 1;
+         Self.Command_T_Send_Dropped_Count := @ + 1;
          Self.Expect_Command_T_Send_Dropped := False;
       end if;
    end Command_T_Send_Dropped;

--- a/src/components/parameter_manager/test/parameter_manager_tests-implementation.adb
+++ b/src/components/parameter_manager/test/parameter_manager_tests-implementation.adb
@@ -92,7 +92,7 @@ package body Parameter_Manager_Tests.Implementation is
       while not Task_Exit.all and then Count < 2000 loop
 
          -- Increment variables:
-         Count := Count + 1;
+         Count := @ + 1;
 
          if Task_Send_Response then
             -- Send a valid response:
@@ -115,7 +115,7 @@ package body Parameter_Manager_Tests.Implementation is
             -- Send a valid response:
             Sleep (4);
             Class_Self.all.Tester.Timeout_Tick_Send (((0, 0), 0));
-            Tick_Count := Tick_Count + 1;
+            Tick_Count := @ + 1;
             if Tick_Count > 4 then
                Tick_Count := 0;
                Task_Send_Timeout := False;

--- a/src/last_chance_handler/linux/last_chance_handler.adb
+++ b/src/last_chance_handler/linux/last_chance_handler.adb
@@ -22,7 +22,7 @@ package body Last_Chance_Handler is
       GNAT.IO.Put ("LCH called => ");
       while Peek (A) /= ASCII.NUL loop
          GNAT.IO.Put (Peek (A));
-         A := A + 1;
+         A := @ + 1;
       end loop;
       GNAT.IO.Put (": ");
       GNAT.IO.Put (Line); -- avoid the secondary stack for Line'Image

--- a/src/last_chance_handler/pico/last_chance_handler.adb
+++ b/src/last_chance_handler/pico/last_chance_handler.adb
@@ -50,7 +50,7 @@ package body Last_Chance_Handler is
             Packed_Exception_Data.Exception_Name (Copy_Idx) := Char_To_Byte (Char);
 
             -- Don't overflow.
-            Copy_Idx := Copy_Idx + 1;
+            Copy_Idx := @ + 1;
             if Copy_Idx > Packed_Exception_Data.Exception_Name'Last then
                exit;
             end if;
@@ -66,7 +66,7 @@ package body Last_Chance_Handler is
             Packed_Exception_Data.Exception_Message (Copy_Idx) := Char_To_Byte (Char);
 
             -- Don't overflow.
-            Copy_Idx := Copy_Idx + 1;
+            Copy_Idx := @ + 1;
             if Copy_Idx > Packed_Exception_Data.Exception_Message'Last then
                exit;
             end if;
@@ -196,7 +196,7 @@ package body Last_Chance_Handler is
                   Pico_Uart.Send_Byte_Array (Component.Ccsds_Serial_Interface.Implementation.Sync_Pattern & Pkt_Bytes);
 
                   -- Increment sequence count:
-                  Cnt := Cnt + 1;
+                  Cnt := @ + 1;
                end loop;
             end;
          end;

--- a/src/pico_util/hello_pico/hello_pico.gpr
+++ b/src/pico_util/hello_pico/hello_pico.gpr
@@ -18,7 +18,7 @@ project Hello_Pico is
    for Main use ("main.adb");
 
    package Compiler is
-      for Default_Switches ("Ada") use Adamant_Example_Config.Ada_Compiler_Switches;
+      for Default_Switches ("Ada") use Adamant_Example_Config.Ada_Compiler_Switches & ("-gnat2022");
    end Compiler;
 
    package Binder is

--- a/src/pico_util/hello_pico/main.adb
+++ b/src/pico_util/hello_pico/main.adb
@@ -60,7 +60,7 @@ begin
       --delay 0.2;
 
       -- Next release time
-      Release := Release + Period;
+      Release := @ + Period;
       Send_Hello;
       -- RP.Device.Timer.Delay_Milliseconds (250);
    end loop;


### PR DESCRIPTION
Using this Fish script:
```fish
# requires moreutils and ripgrep
for i in 1 2
    set -l regex '^(\s*(\S.*?)\h+:=.*?(\h|\())\2((\.|\h|\)).*?;)'
    for file in (rg -P --multiline $regex -l)
        rg -P --multiline $regex -r '$1@$4' "$file" -N --passthru | sponge "$file"
    end
end
```