### PR TITLE
Add fast environment activation for automated tools

### DIFF
--- a/docker/adamant_env.sh
+++ b/docker/adamant_env.sh
@@ -38,10 +38,11 @@ execute () {
 }
 
 usage() {
-  echo "Usage: $1 [start, stop, login, pull, push, build, buildx, pushx, remove]" >&2
+  echo "Usage: $1 [start, stop, login, exec, pull, push, build, buildx, pushx, remove]" >&2
   echo "*  start: create and start the ${PROJECT_NAME} container" >&2
   echo "*  stop: stop the running ${PROJECT_NAME} container" >&2
   echo "*  login: login to the ${PROJECT_NAME} container" >&2
+  echo "*  exec: execute a command in the container (fast activation)" >&2
   echo "*  pull: pull the latest image from the Docker registry" >&2
   echo "*  push: push the image to the Docker registry" >&2
   echo "*  build: build the image from the Dockerfile (single platform)" >&2
@@ -66,6 +67,11 @@ case $1 in
     ;;
   login )
     execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} exec -it -u user ${PROJECT_NAME} //bin//bash"
+    ;;
+  exec )
+    shift
+    ${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} exec -u user ${PROJECT_NAME} \
+      /home/user/${PROJECT_NAME}/env/container_run.sh "$@"
     ;;
   pull )
     execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} pull"

--- a/env/activate
+++ b/env/activate
@@ -53,4 +53,8 @@ fi
 # Signify the environment it set up:
 export EXAMPLE_ENVIRONMENT_SET="yes"
 
+# Save environment snapshot for fast re-activation by automated tools.
+# Stored in /tmp so it is automatically invalidated on container restart.
+export -p > /tmp/.adamant_example_env_snapshot
+
 echo "Done."

--- a/env/activate_from_snapshot
+++ b/env/activate_from_snapshot
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fast activation for automated tools.
+# Thin wrapper around the core activate_from_snapshot in adamant.
+# See adamant/env/activate_from_snapshot for details.
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export ADAMANT_DIR="${ADAMANT_DIR:-$(readlink -f "$_SCRIPT_DIR/../../adamant")}"
+unset _SCRIPT_DIR
+
+. "$ADAMANT_DIR/env/activate_from_snapshot" \
+    "/tmp/.adamant_example_env_snapshot" \
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/activate" \
+    "EXAMPLE_ENVIRONMENT_SET"

--- a/env/container_run.sh
+++ b/env/container_run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Activate the environment from snapshot and run a command.
+# Intended for automated tools where fast activation is critical.
+#
+# Usage (inside container):
+#   container_run.sh "cd /path && redo test"
+#
+# Usage (via adamant_env.sh from host):
+#   ./adamant_env.sh exec "cd /path && redo test"
+
+this_dir=`dirname "$0"`
+. $this_dir/activate_from_snapshot
+
+# Run the command passed to the script:
+echo "$ $@"
+eval "$@"


### PR DESCRIPTION
Automated tools running commands via docker exec pay seconds of overhead per invocation After the first activation, all of this is redundant and only the environment variables are needed.

Add an environment snapshot system: activate saves `export -p` to a file in /tmp after setup completes, and activate_from_snapshot restores it in very quickly. The /tmp location ensures the cache is automatically invalidated on container restart.

New files:
- env/activate_from_snapshot: core reusable loader (adamant) / thin project wrapper that sources the snapshot or falls back to full activate
- env/container_run.sh: inside-container script that activates from snapshot and runs a command (parallel github_run.sh)

Modified files:
- env/activate: saves environment snapshot after activation
- docker/adamant_env.sh: added "exec" command for running commands in the container with fast activation

Usage:
  ./docker/adamant_env.sh exec "cd /path && redo test"