### PR TITLE
Add refresh command to rebuild cached environment snapshot

### DIFF
--- a/docker/adamant_env.sh
+++ b/docker/adamant_env.sh
@@ -38,11 +38,13 @@ execute () {
 }
 
 usage() {
-  echo "Usage: $1 [start, stop, login, exec, pull, push, build, buildx, pushx, remove]" >&2
+  echo "Usage: $1 [start, stop, login, exec, refresh, pull, push, build, buildx, pushx, remove]" >&2
   echo "*  start: create and start the ${PROJECT_NAME} container" >&2
   echo "*  stop: stop the running ${PROJECT_NAME} container" >&2
   echo "*  login: login to the ${PROJECT_NAME} container" >&2
   echo "*  exec: execute a command in the container (fast activation)" >&2
+  echo "*  refresh: re-activate and rebuild the cached environment snapshot" >&2
+  echo "           (needed after changing activate, requirements, __init__.py, etc.)" >&2
   echo "*  pull: pull the latest image from the Docker registry" >&2
   echo "*  push: push the image to the Docker registry" >&2
   echo "*  build: build the image from the Dockerfile (single platform)" >&2
@@ -72,6 +74,12 @@ case $1 in
     shift
     ${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} exec -u user ${PROJECT_NAME} \
       /home/user/${PROJECT_NAME}/env/container_run.sh "$@"
+    ;;
+  refresh )
+    execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} exec -u user ${PROJECT_NAME} \
+      bash /home/user/${PROJECT_NAME}/env/refresh_snapshot.sh"
+    echo ""
+    echo "Environment snapshot refreshed."
     ;;
   pull )
     execute "${DOCKER_COMPOSE_COMMAND} -f ${DOCKER_COMPOSE_CONFIG} pull"

--- a/env/refresh_snapshot.sh
+++ b/env/refresh_snapshot.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Delete cached environment snapshots and re-run full activation to
+# rebuild them. Run this after changing env/activate, requirements*.txt,
+# alire.toml, adding/removing __init__.py files (which affect the Python
+# path), or anything else that influences the environment.
+#
+# Usage (inside container):
+#   ./refresh_snapshot.sh
+#
+# Usage (via adamant_env.sh from host):
+#   ./adamant_env.sh refresh
+
+this_dir=`dirname "$0"`
+
+if test -z "$ADAMANT_DIR"
+then
+    export ADAMANT_DIR=`readlink -f "$this_dir/../../adamant"`
+fi
+
+# Clear adamant's cached state without activating, since this repo's
+# activate will chain into adamant's activate.
+. $ADAMANT_DIR/env/refresh_snapshot.sh --no-activate
+
+rm -f /tmp/.adamant_example_env_snapshot
+unset EXAMPLE_ENVIRONMENT_SET
+. $this_dir/activate


### PR DESCRIPTION
- Adds `env/refresh_snapshot.sh` that clears both adamant's and this repo's cached state, then re-runs full activation to rebuild snapshots
- Adds `refresh` command to `adamant_env.sh` to invoke it from the host
- Depends on lasp/adamant#156 (`--no-activate` flag)